### PR TITLE
Remove unused work section from scroll spy

### DIFF
--- a/Home.tsx
+++ b/Home.tsx
@@ -49,7 +49,8 @@ const caseStudies = [
 
 export default function Home() {
   const { setActiveSection } = useOutletContext<LayoutContext>();
-  const activeId = useScrollSpy(["work", "approach", "lab"]);
+  // TODO: Reintroduce the "work" section ID here when the section is implemented.
+  const activeId = useScrollSpy(["approach", "lab"]);
 
   useEffect(() => {
     setActiveSection(activeId);


### PR DESCRIPTION
## Summary
- ensure the scroll spy only tracks sections that exist on the page
- leave a TODO note to restore the work section once it is implemented

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cec6fdc640832b96b9decb42b24311