### PR TITLE
Add static serve script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",
-        "preview": "vite preview"
+        "preview": "vite preview",
+        "serve:static": "npx serve -s dist -l 5173"
     },
     "dependencies": {
         "@p5-wrapper/react": "^4.4.2",


### PR DESCRIPTION
## Summary
- add a `serve:static` npm script that serves the built dist directory on port 5173 using `npx serve -s`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cec7490fe8832b934365cec8785d17