### PR TITLE
Align Framer Motion transitions with design tokens

### DIFF
--- a/src/components/ContactDrawer.tsx
+++ b/src/components/ContactDrawer.tsx
@@ -2,6 +2,7 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useCharCount } from "../hooks/useCharCount";
+import { MotionDurations, MotionEasings } from "../styles/motion";
 
 const EMAIL_PATTERN = /[^\s@]+@[^\s@]+\.[^\s@]+/;
 const MESSAGE_LIMIT = 500;
@@ -81,7 +82,7 @@ export function ContactDrawer({ open, onClose }: ContactDrawerProps) {
             className="fixed inset-0 z-30"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            exit={{ opacity: 0, transition: { duration: 0.15 } }}
+            exit={{ opacity: 0, transition: { duration: MotionDurations.duration160 } }}
           >
             <motion.div
               role="presentation"
@@ -89,7 +90,7 @@ export function ContactDrawer({ open, onClose }: ContactDrawerProps) {
               onClick={onClose}
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
-              exit={{ opacity: 0, transition: { duration: 0.15 } }}
+              exit={{ opacity: 0, transition: { duration: MotionDurations.duration160 } }}
             />
             <motion.div
               ref={sheetRef}
@@ -99,8 +100,8 @@ export function ContactDrawer({ open, onClose }: ContactDrawerProps) {
               className="absolute inset-x-0 bottom-0 mx-auto w-full max-w-3xl rounded-t-[32px] border border-hairline border-b-0 bg-ink/96 backdrop-blur-lg"
               initial={{ y: "100%" }}
               animate={{ y: 0 }}
-              exit={{ y: "100%", transition: { duration: 0.2, ease: [0.4, 0, 0.2, 1] } }}
-              transition={{ duration: 0.24, ease: [0.33, 1, 0.68, 1] }}
+              exit={{ y: "100%", transition: { duration: MotionDurations.transitionIn, ease: MotionEasings.tIn } }}
+              transition={{ duration: MotionDurations.transitionOut, ease: MotionEasings.tOut }}
             >
               <div className="flex flex-col gap-6 px-6 pb-10 pt-8 sm:px-10">
                 <div className="flex items-start justify-between gap-4">
@@ -163,7 +164,7 @@ export function ContactDrawer({ open, onClose }: ContactDrawerProps) {
                         key="sent"
                         initial={{ opacity: 0, y: 6 }}
                         animate={{ opacity: 1, y: 0 }}
-                        exit={{ opacity: 0, y: -6, transition: { duration: 0.12 } }}
+                        exit={{ opacity: 0, y: -6, transition: { duration: MotionDurations.duration120 } }}
                         className="rounded-full border border-lavend/50 bg-lavend/10 px-4 py-2 text-center text-xs text-lavend"
                       >
                         Sent (stub)

--- a/src/components/CustomCursor.tsx
+++ b/src/components/CustomCursor.tsx
@@ -1,5 +1,6 @@
 ﻿import { motion, useMotionValue, useReducedMotion, useSpring } from "framer-motion";
 import { useEffect, useMemo, useState } from "react";
+import { MotionDurations, MotionEasings } from "../styles/motion";
 
 type CursorVariant = "default" | "hover" | "drag" | "hidden" | "reduced";
 
@@ -132,7 +133,7 @@ export function CustomCursor() {
           backgroundColor: "rgba(245,245,247,0.1)",
         },
       }}
-      transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+      transition={{ duration: MotionDurations.transitionIn, ease: MotionEasings.calm }}
     >
       <div className="flex h-full w-full items-center justify-center">
         {!prefersReducedMotion && activeVariant === "hover" ? (

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -13,6 +13,7 @@ import {
   useMemo,
   type MouseEvent as ReactMouseEvent,
 } from "react";
+import { MotionDurations, MotionEasings, sumDurations } from "../styles/motion";
 
 type Cta = {
   label: string;
@@ -38,10 +39,10 @@ export type HeroSectionProps = {
   id?: string;
 };
 
-const EASE = [0.4, 0, 0.2, 1] as const;
 const TILE_DEPTH_PATTERN = [1, -0.7, 0.55, -0.4];
 const MAX_OFFSET = 14;
 const SPRING_CONFIG = { stiffness: 140, damping: 22, mass: 0.6 };
+const STACKED_DURATION = sumDurations(MotionDurations.duration240, MotionDurations.duration160);
 
 type HeroTileProps = {
   tile: Tile;
@@ -109,8 +110,8 @@ export default function HeroSection({
         opacity: 1,
         y: 0,
         transition: {
-          duration: prefersReducedMotion ? 0.18 : 0.32,
-          ease: EASE,
+          duration: prefersReducedMotion ? MotionDurations.transitionIn : MotionDurations.duration320,
+          ease: MotionEasings.calm,
           when: "beforeChildren",
           staggerChildren: prefersReducedMotion ? 0 : 0.08,
         },
@@ -125,7 +126,10 @@ export default function HeroSection({
       show: {
         opacity: 1,
         y: 0,
-        transition: { duration: prefersReducedMotion ? 0.2 : 0.3, ease: EASE },
+        transition: {
+          duration: prefersReducedMotion ? MotionDurations.transitionIn : MotionDurations.duration320,
+          ease: MotionEasings.calm,
+        },
       },
     }),
     [prefersReducedMotion],
@@ -138,8 +142,8 @@ export default function HeroSection({
         opacity: 1,
         y: 0,
         transition: {
-          duration: prefersReducedMotion ? 0.2 : 0.32,
-          ease: EASE,
+          duration: prefersReducedMotion ? MotionDurations.transitionIn : MotionDurations.duration320,
+          ease: MotionEasings.calm,
           staggerChildren: prefersReducedMotion ? 0 : 0.08,
         },
       },
@@ -153,7 +157,10 @@ export default function HeroSection({
       show: {
         opacity: 1,
         y: 0,
-        transition: { duration: prefersReducedMotion ? 0.2 : 0.28, ease: EASE },
+        transition: {
+          duration: prefersReducedMotion ? MotionDurations.transitionIn : MotionDurations.duration320,
+          ease: MotionEasings.calm,
+        },
       },
     }),
     [prefersReducedMotion],
@@ -166,8 +173,8 @@ export default function HeroSection({
         opacity: 1,
         y: 0,
         transition: {
-          duration: prefersReducedMotion ? 0.24 : 0.36,
-          ease: EASE,
+          duration: prefersReducedMotion ? MotionDurations.duration240 : STACKED_DURATION,
+          ease: MotionEasings.calm,
           staggerChildren: prefersReducedMotion ? 0 : 0.08,
         },
       },
@@ -182,8 +189,8 @@ export default function HeroSection({
         opacity: 1,
         y: 0,
         transition: {
-          duration: prefersReducedMotion ? 0.22 : 0.38,
-          ease: EASE,
+          duration: prefersReducedMotion ? MotionDurations.duration240 : MotionDurations.duration400,
+          ease: MotionEasings.calm,
           delay: prefersReducedMotion ? 0 : index * 0.05,
         },
       }),

--- a/src/components/MenuOverlay.tsx
+++ b/src/components/MenuOverlay.tsx
@@ -2,21 +2,26 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent } from "react";
+import { MotionDurations, MotionEasings } from "../styles/motion";
 
 const panelVariants = {
   closed: {
     clipPath: "inset(var(--mask-top, 50%) var(--mask-right, 50%) var(--mask-bottom, 50%) var(--mask-left, 50%) round var(--mask-radius, 24px))",
-    transition: { duration: 0.22, ease: [0.4, 0, 0.2, 1] },
+    transition: { duration: MotionDurations.transitionOut, ease: MotionEasings.tIn },
   },
   open: {
     clipPath: "inset(0% 0% 0% 0% round 0px)",
-    transition: { duration: 0.24, ease: [0.33, 1, 0.68, 1] },
+    transition: { duration: MotionDurations.transitionOut, ease: MotionEasings.tOut },
   },
 };
 
 const containerVariants = {
   hidden: { opacity: 0, y: 12 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.28, ease: [0.4, 0, 0.2, 1] } },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: MotionDurations.duration320, ease: MotionEasings.calm },
+  },
 };
 
 type NavTarget = "work" | "resume" | "about" | "contact";
@@ -100,7 +105,7 @@ export function MenuOverlay({ open, maskStyle, onClose, onNavigate }: MenuOverla
             className="fixed inset-0 z-40 flex items-stretch justify-center"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            exit={{ opacity: 0, transition: { duration: 0.15 } }}
+            exit={{ opacity: 0, transition: { duration: MotionDurations.duration160 } }}
           >
             <motion.div
               id="main-menu-overlay"

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,6 +1,7 @@
 ﻿import { LayoutGroup, motion } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent } from "react";
+import { MotionDurations, MotionEasings } from "../styles/motion";
 
 const NAV_LINKS = [
   { id: "work" as const, label: "Work" },
@@ -132,7 +133,7 @@ export function NavBar({
       className="pointer-events-none fixed left-0 right-0 top-0 z-40 flex justify-center"
       initial={false}
       animate={{ y: hidden ? "-110%" : 0 }}
-      transition={{ duration: 0.24, ease: [0.33, 1, 0.68, 1] }}
+      transition={{ duration: MotionDurations.transitionOut, ease: MotionEasings.tOut }}
     >
       <nav
         aria-label="Primary"

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,7 @@
 import { motion } from "framer-motion";
 import { useOutletContext } from "react-router-dom";
 import type { LayoutContext } from "../App";
+import { MotionDurations, MotionEasings } from "../styles/motion";
 
 export default function About() {
   const { openContact } = useOutletContext<LayoutContext>();
@@ -11,7 +12,7 @@ export default function About() {
         className="font-display text-4xl text-foam sm:text-5xl"
         initial={{ opacity: 0, y: 24 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.24, ease: [0.4, 0, 0.2, 1] }}
+        transition={{ duration: MotionDurations.duration240, ease: MotionEasings.calm }}
       >
         About AetherLab
       </motion.h1>
@@ -19,7 +20,7 @@ export default function About() {
         className="max-w-3xl text-lg leading-relaxed text-haze"
         initial={{ opacity: 0, y: 24 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.24, ease: [0.4, 0, 0.2, 1], delay: 0.08 }}
+        transition={{ duration: MotionDurations.duration240, ease: MotionEasings.calm, delay: 0.08 }}
       >
         We are a compact team of interaction designers, prototypers, and technical artists applying research-led motion thinking to digital products. Our practice lives where product detail meets brand atmosphere&mdash;where invisible systems require a visual voice.
       </motion.p>
@@ -27,7 +28,7 @@ export default function About() {
         className="grid gap-6 text-sm text-haze"
         initial={{ opacity: 0, y: 24 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.24, ease: [0.4, 0, 0.2, 1], delay: 0.14 }}
+        transition={{ duration: MotionDurations.duration240, ease: MotionEasings.calm, delay: 0.14 }}
       >
         <div className="rounded-3xl border border-hairline/60 bg-ink/50 p-6">
           <h2 className="font-display text-xl text-foam">Lab principles</h2>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,13 +3,18 @@ import { useEffect } from "react";
 import { useOutletContext } from "react-router-dom";
 import type { LayoutContext } from "../App";
 import { PortfolioHero } from "../sections/PortfolioHero";
+import { MotionDurations, MotionEasings } from "../styles/motion";
 
 const cards = {
   hidden: { opacity: 0, y: 16 },
   visible: (i: number) => ({
     opacity: 1,
     y: 0,
-    transition: { duration: 0.24, ease: [0.4, 0, 0.2, 1], delay: i * 0.06 },
+    transition: {
+      duration: MotionDurations.duration240,
+      ease: MotionEasings.calm,
+      delay: i * 0.06,
+    },
   }),
 };
 
@@ -65,7 +70,7 @@ export default function Home() {
               initial={{ opacity: 0, y: 24 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: "-80px" }}
-              transition={{ duration: 0.24, ease: [0.4, 0, 0.2, 1] }}
+              transition={{ duration: MotionDurations.duration240, ease: MotionEasings.calm }}
             >
               <h2 className="font-display text-2xl text-foam sm:text-3xl">How we modulate momentum</h2>
               <p className="mt-4 text-base leading-relaxed text-haze">
@@ -113,7 +118,7 @@ export default function Home() {
             initial={{ opacity: 0, y: 24 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true, margin: "-60px" }}
-            transition={{ duration: 0.24, ease: [0.4, 0, 0.2, 1] }}
+            transition={{ duration: MotionDurations.duration240, ease: MotionEasings.calm }}
           >
             <p className="font-display text-sm uppercase tracking-[0.3em] text-haze">Case signals</p>
             <h2 className="font-display text-3xl text-foam sm:text-4xl">Selected investigations</h2>

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -2,6 +2,7 @@
 import { useEffect } from "react";
 import { useOutletContext } from "react-router-dom";
 import type { LayoutContext } from "../App";
+import { MotionDurations, MotionEasings } from "../styles/motion";
 
 const experience = [
   {
@@ -52,7 +53,11 @@ const cardVariants = {
   visible: (i: number) => ({
     opacity: 1,
     y: 0,
-    transition: { delay: i * 0.05, duration: 0.24, ease: [0.4, 0, 0.2, 1] },
+    transition: {
+      delay: i * 0.05,
+      duration: MotionDurations.duration240,
+      ease: MotionEasings.calm,
+    },
   }),
 };
 

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -2,6 +2,7 @@
 import { useEffect } from "react";
 import { useOutletContext } from "react-router-dom";
 import type { LayoutContext } from "../App";
+import { MotionDurations, MotionEasings } from "../styles/motion";
 
 const projects = [
   {
@@ -35,7 +36,11 @@ const listVariants = {
   visible: (i: number) => ({
     opacity: 1,
     y: 0,
-    transition: { delay: i * 0.05, duration: 0.26, ease: [0.4, 0, 0.2, 1] },
+    transition: {
+      delay: i * 0.05,
+      duration: MotionDurations.duration240,
+      ease: MotionEasings.calm,
+    },
   }),
 };
 

--- a/src/routes/work/index.tsx
+++ b/src/routes/work/index.tsx
@@ -1,5 +1,6 @@
 ﻿import { useEffect, useMemo, useRef, useState, type PointerEvent } from "react";
 import { LayoutGroup, motion, useInView } from "framer-motion";
+import { MotionDurations, MotionEasings } from "../../styles/motion";
 
 type WorkCategory = "product-ui" | "motion-systems" | "prototyping";
 
@@ -135,7 +136,7 @@ const projects: WorkProject[] = [
   },
 ];
 
-const easing = [0.4, 0, 0.2, 1];
+const easing = MotionEasings.calm;
 const MAX_TILT = 6;
 
 export default function WorkCollection() {
@@ -191,7 +192,7 @@ export default function WorkCollection() {
             layout
             initial={{ opacity: 0, y: 24 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.32, ease: easing, delay: index * 0.04 }}
+            transition={{ duration: MotionDurations.duration320, ease: easing, delay: index * 0.04 }}
             className="h-full"
           >
             <WorkCard project={project} />

--- a/src/sections/PortfolioHero.tsx
+++ b/src/sections/PortfolioHero.tsx
@@ -8,10 +8,12 @@ import {
 import { useCallback, useMemo } from "react";
 import type { MouseEvent } from "react";
 import type { MotionValue } from "framer-motion";
+import { MotionDurations, MotionEasings, sumDurations } from "../styles/motion";
 
-const CALM_EASE = [0.32, 0.16, 0.16, 1] as const;
 const PARALLAX_LIMIT = 10;
 const SPRING_CONFIG = { stiffness: 180, damping: 26, mass: 0.8 };
+const CALM_STACK_DURATION = sumDurations(MotionDurations.duration320, MotionDurations.duration240);
+const EXTENDED_OUT_DURATION = sumDurations(MotionDurations.duration240, MotionDurations.duration240);
 
 const CAPABILITIES = [
   "Motion Systems",
@@ -30,8 +32,8 @@ const capabilityTileVariants = {
     opacity: 1,
     y: 0,
     transition: {
-      duration: 0.52,
-      ease: CALM_EASE,
+      duration: CALM_STACK_DURATION,
+      ease: MotionEasings.calm,
       delay: index * 0.06,
     },
   }),
@@ -78,8 +80,8 @@ export function PortfolioHero() {
         opacity: 1,
         y: 0,
         transition: {
-          duration: prefersReducedMotion ? 0.32 : 0.54,
-          ease: CALM_EASE,
+          duration: prefersReducedMotion ? MotionDurations.duration320 : CALM_STACK_DURATION,
+          ease: MotionEasings.calm,
           when: "beforeChildren",
           staggerChildren: prefersReducedMotion ? 0 : 0.08,
         },
@@ -95,8 +97,8 @@ export function PortfolioHero() {
         opacity: 1,
         y: 0,
         transition: {
-          duration: prefersReducedMotion ? 0.28 : 0.48,
-          ease: CALM_EASE,
+          duration: prefersReducedMotion ? MotionDurations.duration320 : EXTENDED_OUT_DURATION,
+          ease: MotionEasings.calm,
         },
       },
     }),
@@ -110,8 +112,8 @@ export function PortfolioHero() {
         opacity: 1,
         y: 0,
         transition: {
-          duration: prefersReducedMotion ? 0.28 : 0.56,
-          ease: CALM_EASE,
+          duration: prefersReducedMotion ? MotionDurations.duration320 : CALM_STACK_DURATION,
+          ease: MotionEasings.calm,
         },
       },
     }),

--- a/src/styles/motion.ts
+++ b/src/styles/motion.ts
@@ -1,14 +1,45 @@
+const duration120 = 0.12;
+const duration160 = 0.16;
+const duration180 = 0.18;
+const duration240 = 0.24;
+const duration320 = 0.32;
+const duration400 = 0.4;
+
+export const MotionDurations = {
+  duration120,
+  duration160,
+  duration180,
+  duration240,
+  duration320,
+  duration400,
+  transitionIn: duration180,
+  transitionOut: duration240,
+  transitionSnap: duration320,
+} as const;
+
+export const MotionEasings = {
+  tIn: [0.32, 0, 0.67, 0] as const,
+  tOut: [0.33, 1, 0.68, 1] as const,
+  tSnap: [0.16, 1, 0.3, 1] as const,
+  calm: [0.215, 0.61, 0.355, 1] as const,
+  calmInOut: [0.86, 0, 0.07, 1] as const,
+} as const;
+
+export function sumDurations(...durations: number[]): number {
+  return durations.reduce((total, value) => total + value, 0);
+}
+
 export const calmMotion = {
-  easeOutQuart: [0.215, 0.61, 0.355, 1],
-  easeInOutQuint: [0.86, 0, 0.07, 1],
+  easeOutQuart: MotionEasings.calm,
+  easeInOutQuint: MotionEasings.calmInOut,
   spring: {
     type: "spring" as const,
     stiffness: 90,
     damping: 22,
     mass: 1,
     restDelta: 0.002,
-    restSpeed: 0.01
-  }
+    restSpeed: 0.01,
+  },
 } as const;
 
 export type CalmMotionKey = keyof typeof calmMotion;


### PR DESCRIPTION
## Summary
- add shared motion duration and easing constants that mirror the design token values and retain the existing calm motion helpers
- refactor overlay, navigation, cursor, and contact components to source their Framer Motion transitions from the shared motion tokens
- update hero modules and routed pages to apply the tokenized motion timings for consistent easing across scroll and reveal animations

## Testing
- `npm run build` *(fails: `vite` missing execute permission in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cec740ece4832b8e726887e9caf2c5