### PR TITLE
Add NotFound page for unmatched routes

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import App from "./App";
 import Home from "./pages/Home";
 import About from "./pages/About";
+import NotFound from "./pages/NotFound";
 import Resume from "./routes/resume";
 import Work from "./pages/Work";
 import "./styles/globals.css";
@@ -18,6 +19,7 @@ const router = createBrowserRouter([
       { path: "resume", element: <Resume /> },
       { path: "about", element: <About /> },
       { path: "contact", element: <Home /> },
+      { path: "*", element: <NotFound /> },
     ],
   },
 ]);

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,24 @@
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  return (
+    <div className="mx-auto flex min-h-[60vh] w-full max-w-3xl flex-col items-center justify-center gap-8 py-24 text-center">
+      <div className="flex flex-col items-center gap-4">
+        <span className="rounded-full border border-hairline/60 bg-ink/60 px-4 py-1 text-xs uppercase tracking-[0.3em] text-haze">
+          404
+        </span>
+        <h1 className="font-display text-3xl text-foam sm:text-4xl">Page not found</h1>
+        <p className="max-w-xl text-sm leading-relaxed text-haze">
+          The page you were seeking drifted outside our constellation. Return to the hub to continue exploring the portfolio.
+        </p>
+      </div>
+      <Link
+        to="/"
+        className="inline-flex items-center gap-2 rounded-full border border-lavend/50 bg-lavend/10 px-5 py-2 text-sm font-medium text-lavend transition-colors duration-150 hover:border-lavend hover:bg-lavend/20"
+        data-cursor="hover"
+      >
+        Back to home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated NotFound page that uses existing design tokens and links visitors back to the home page
- register the catch-all route so unmatched URLs render the new component inside the main layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cec70e7084832ba9be5acd44a2a3fa