### PR TITLE
Update Vite scripts to bind host and port

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "dev": "vite",
+        "dev": "vite --host --port 5173",
         "build": "tsc && vite build",
-        "preview": "vite preview"
+        "preview": "vite preview --host --port 5173"
     },
     "dependencies": {
         "@p5-wrapper/react": "^4.4.2",


### PR DESCRIPTION
## Summary
- update the Vite dev script to bind the host and port 5173
- update the Vite preview script to bind the host and port 5173

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cec6ccea38832b94c067d85bbf3568