### PR TITLE
Update resume CTA to use internal route

### DIFF
--- a/src/sections/PortfolioHero.tsx
+++ b/src/sections/PortfolioHero.tsx
@@ -188,7 +188,7 @@ export function PortfolioHero() {
               View Work
             </a>
             <a
-              href="/resume.pdf"
+              href="/resume"
               aria-label="Download Rowan Sato resume"
               className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-foam transition-colors duration-200 hover:border-lavend hover:text-lavend focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend/60 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
             >


### PR DESCRIPTION
## Summary
- update the PortfolioHero resume call-to-action to link to `/resume` instead of the PDF asset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cec6aa04a8832bbac704e2e4347191