### PR TITLE
Fix lavender tailwind class names

### DIFF
--- a/Home.tsx
+++ b/Home.tsx
@@ -76,15 +76,15 @@ export default function Home() {
               </p>
               <div className="mt-6 grid gap-4 text-sm text-haze">
                 <div className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-lavend" />
+                  <span className="h-2 w-2 rounded-full bg-lavender" />
                   Research sprints, brand tune-ups, motion guidelines
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-lavend" />
+                  <span className="h-2 w-2 rounded-full bg-lavender" />
                   Prototype rigs, developer handoff, performance audits
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-lavend" />
+                  <span className="h-2 w-2 rounded-full bg-lavender" />
                   Embedded collaborations from seed to scale
                 </div>
               </div>
@@ -125,7 +125,7 @@ export default function Home() {
             {caseStudies.map((project, index) => (
               <motion.article
                 key={project.name}
-                className="group grid gap-4 rounded-[32px] border border-hairline/70 bg-ink/50 p-6 transition-colors duration-150 hover:border-lavend"
+                className="group grid gap-4 rounded-[32px] border border-hairline/70 bg-ink/50 p-6 transition-colors duration-150 hover:border-lavender"
                 variants={cards}
                 initial="hidden"
                 whileInView="visible"
@@ -139,8 +139,8 @@ export default function Home() {
                   </span>
                 </div>
                 <p className="text-sm leading-relaxed text-haze group-hover:text-foam">{project.description}</p>
-                <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-lavend">
-                  <span className="h-px w-8 bg-lavend/70" />
+                <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-lavender">
+                  <span className="h-px w-8 bg-lavender/70" />
                   Inquire for release notes
                 </div>
               </motion.article>

--- a/PortfolioHero.tsx
+++ b/PortfolioHero.tsx
@@ -175,10 +175,10 @@ export function PortfolioHero() {
           </motion.p>
           <motion.div className="flex flex-wrap items-center gap-3 text-sm text-haze" variants={identityItemVariants}>
             <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.28em] text-foam">
-              <span className="h-2 w-2 rounded-full bg-lavend" />
+              <span className="h-2 w-2 rounded-full bg-lavender" />
               Portland, OR
             </span>
-            <span className="inline-flex items-center gap-2 rounded-full border border-lavend/40 bg-lavend/10 px-4 py-2 text-xs uppercase tracking-[0.28em] text-lavend">
+            <span className="inline-flex items-center gap-2 rounded-full border border-lavender/40 bg-lavender/10 px-4 py-2 text-xs uppercase tracking-[0.28em] text-lavender">
               Open for Q3 collaborations
             </span>
           </motion.div>
@@ -186,16 +186,16 @@ export function PortfolioHero() {
             <a
               href="#work"
               aria-label="View selected work"
-              className="inline-flex items-center justify-center rounded-full bg-lavend px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-ink transition-colors duration-200 hover:bg-lavend-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+              className="inline-flex items-center justify-center rounded-full bg-lavender px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-ink transition-colors duration-200 hover:bg-lavender-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
             >
               View Work
             </a>
             <a
               href="/resume.pdf"
-              aria-label="Download Rowan Sato résumé"
+              className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-foam transition-colors duration-200 hover:border-lavender hover:text-lavender focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender/60 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
               className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-foam transition-colors duration-200 hover:border-lavend hover:text-lavend focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend/60 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
             >
-              Download Résumé
+              Download RÃ©sumÃ©
             </a>
           </motion.div>
         </motion.div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,12 +153,12 @@ export default function App() {
           <div className="flex flex-col gap-4 rounded-[28px] border border-hairline/70 bg-ink/60 px-6 py-6 backdrop-blur sm:flex-row sm:items-center sm:justify-between">
             <p className="text-sm text-haze">&copy; {new Date().getFullYear()} AetherLab. All composites original.</p>
             <div className="flex flex-wrap items-center gap-4 text-sm uppercase tracking-[0.24em] text-haze">
-              <Link to="/about" className="transition-colors duration-150 hover:text-lavend" data-cursor="hover">
+              <Link to="/about" className="transition-colors duration-150 hover:text-lavender" data-cursor="hover">
                 About
               </Link>
               <button
                 type="button"
-                className="text-left transition-colors duration-150 hover:text-lavend"
+                className="text-left transition-colors duration-150 hover:text-lavender"
                 data-cursor="hover"
                 onClick={openContact}
               >

--- a/src/components/ContactDrawer.tsx
+++ b/src/components/ContactDrawer.tsx
@@ -61,8 +61,8 @@ export function ContactDrawer({ open, onClose }: ContactDrawerProps) {
   };
 
   const hintTone = useMemo(() => {
-    if (error) return "text-lavend-deep";
-    if (remaining < 50) return "text-lavend-deep";
+    if (error) return "text-lavender-deep";
+    if (remaining < 50) return "text-lavender-deep";
     return "text-haze";
   }, [error, remaining]);
 
@@ -128,7 +128,7 @@ export function ContactDrawer({ open, onClose }: ContactDrawerProps) {
                       value={email}
                       onChange={(event) => setEmail(event.target.value)}
                       required
-                      className="rounded-2xl border border-hairline bg-transparent px-4 py-3 text-base text-foam focus:border-lavend focus:outline-none focus:ring-2 focus:ring-lavend/40"
+                      className="rounded-2xl border border-hairline bg-transparent px-4 py-3 text-base text-foam focus:border-lavender focus:outline-none focus:ring-2 focus:ring-lavender/40"
                     />
                   </label>
                   <label className="flex flex-col gap-2 text-sm text-haze">
@@ -139,7 +139,7 @@ export function ContactDrawer({ open, onClose }: ContactDrawerProps) {
                       onChange={(event) => setMessage(event.target.value)}
                       maxLength={MESSAGE_LIMIT}
                       rows={5}
-                      className="scroll-area rounded-2xl border border-hairline bg-transparent px-4 py-3 text-base text-foam focus:border-lavend focus:outline-none focus:ring-2 focus:ring-lavend/40"
+                      className="scroll-area rounded-2xl border border-hairline bg-transparent px-4 py-3 text-base text-foam focus:border-lavender focus:outline-none focus:ring-2 focus:ring-lavender/40"
                     />
                   </label>
                   <div className="flex items-center justify-between text-xs">
@@ -151,7 +151,7 @@ export function ContactDrawer({ open, onClose }: ContactDrawerProps) {
                   <motion.button
                     type="submit"
                     data-cursor="hover"
-                    className="inline-flex items-center justify-center gap-2 rounded-full bg-lavend px-6 py-3 font-display text-sm uppercase tracking-[0.3em] text-ink transition-colors duration-150 hover:bg-lavend-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-lavender px-6 py-3 font-display text-sm uppercase tracking-[0.3em] text-ink transition-colors duration-150 hover:bg-lavender-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
                     whileHover={{ scale: 1.02 }}
                     whileTap={{ scale: 0.97 }}
                   >
@@ -164,7 +164,7 @@ export function ContactDrawer({ open, onClose }: ContactDrawerProps) {
                         initial={{ opacity: 0, y: 6 }}
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: -6, transition: { duration: 0.12 } }}
-                        className="rounded-full border border-lavend/50 bg-lavend/10 px-4 py-2 text-center text-xs text-lavend"
+                        className="rounded-full border border-lavender/50 bg-lavender/10 px-4 py-2 text-center text-xs text-lavender"
                       >
                         Sent (stub)
                       </motion.div>

--- a/src/components/MenuOverlay.tsx
+++ b/src/components/MenuOverlay.tsx
@@ -108,7 +108,7 @@ export function MenuOverlay({ open, maskStyle, onClose, onNavigate }: MenuOverla
               aria-modal="true"
               aria-label="Site navigation"
               style={{ ...maskStyle, ...backgroundStyle }}
-              className="relative flex h-full w-full items-center justify-center bg-lavend text-ink"
+              className="relative flex h-full w-full items-center justify-center bg-lavender text-ink"
               variants={panelVariants}
               initial="closed"
               animate="open"
@@ -119,7 +119,7 @@ export function MenuOverlay({ open, maskStyle, onClose, onNavigate }: MenuOverla
                 type="button"
                 data-cursor="hover"
                 onClick={onClose}
-                className="absolute right-6 top-6 flex h-11 w-11 items-center justify-center rounded-full border border-ink/20 text-xs font-medium uppercase tracking-[0.24em] text-ink transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/40 focus-visible:ring-offset-2 focus-visible:ring-offset-lavend"
+                className="absolute right-6 top-6 flex h-11 w-11 items-center justify-center rounded-full border border-ink/20 text-xs font-medium uppercase tracking-[0.24em] text-ink transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/40 focus-visible:ring-offset-2 focus-visible:ring-offset-lavender"
                 whileHover={{ backgroundColor: "rgba(11, 11, 11, 0.08)" }}
                 whileTap={{ scale: 0.94 }}
               >
@@ -145,7 +145,7 @@ export function MenuOverlay({ open, maskStyle, onClose, onNavigate }: MenuOverla
                           }}
                           type="button"
                           data-cursor="hover"
-                          className="font-display text-5xl font-semibold tracking-tight text-ink transition-colors duration-150 hover:text-lavend-deep focus-visible:text-lavend-deep sm:text-6xl"
+                          className="font-display text-5xl font-semibold tracking-tight text-ink transition-colors duration-150 hover:text-lavender-deep focus-visible:text-lavender-deep sm:text-6xl"
                           whileHover={{ scale: 1.02 }}
                           whileTap={{ scale: 0.97 }}
                           onClick={() => {

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -114,7 +114,7 @@ export function NavBar({
         <a
           href={HREF_MAP[linkId]}
           data-cursor="hover"
-          className="relative z-10 inline-flex items-center justify-center px-4 py-2 text-sm font-medium uppercase tracking-[0.28em] text-foam transition-colors duration-150 hover:text-lavend focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend/50 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+          className="relative z-10 inline-flex items-center justify-center px-4 py-2 text-sm font-medium uppercase tracking-[0.28em] text-foam transition-colors duration-150 hover:text-lavender focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender/50 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
           onMouseEnter={() => setHovered(linkId)}
           onMouseLeave={() => setHovered(null)}
           onFocus={() => setHovered(linkId)}
@@ -146,7 +146,7 @@ export function NavBar({
         <div className="flex items-center justify-center">
           <button
             type="button"
-            className="lg:hidden flex h-10 w-10 items-center justify-center rounded-full border border-hairline/30 text-foam transition-colors duration-150 hover:border-lavend hover:text-lavend focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend/50 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+            className="lg:hidden flex h-10 w-10 items-center justify-center rounded-full border border-hairline/30 text-foam transition-colors duration-150 hover:border-lavender hover:text-lavender focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender/50 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
             aria-label="Open navigation menu"
             data-cursor="hover"
             onClick={(event) => onToggleMenu(event)}
@@ -168,7 +168,7 @@ export function NavBar({
             type="button"
             data-cursor="hover"
             onClick={onStartProject}
-            className="inline-flex whitespace-nowrap rounded-full bg-lavend px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-ink transition-transform transition-colors duration-150 hover:bg-lavend-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+            className="inline-flex whitespace-nowrap rounded-full bg-lavender px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-ink transition-transform transition-colors duration-150 hover:bg-lavender-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
           >
             Hire Me
           </button>
@@ -178,7 +178,7 @@ export function NavBar({
             onClick={onToggleMenu}
             aria-expanded={menuOpen}
             aria-controls="main-menu-overlay"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-hairline text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-foam transition-colors duration-150 hover:border-lavend hover:text-lavend focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend/50 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-hairline text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-foam transition-colors duration-150 hover:border-lavender hover:text-lavender focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender/50 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
             whileTap={{ scale: 0.94 }}
           >
             Menu

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -47,7 +47,7 @@ export default function About() {
             type="button"
             data-cursor="hover"
             onClick={openContact}
-            className="mt-4 inline-flex items-center justify-center rounded-full bg-lavend px-5 py-3 font-display text-xs uppercase tracking-[0.3em] text-ink transition-colors duration-150 hover:bg-lavend-deep hover:text-foam"
+            className="mt-4 inline-flex items-center justify-center rounded-full bg-lavender px-5 py-3 font-display text-xs uppercase tracking-[0.3em] text-ink transition-colors duration-150 hover:bg-lavender-deep hover:text-foam"
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.97 }}
           >

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -73,15 +73,15 @@ export default function Home() {
               </p>
               <div className="mt-6 grid gap-4 text-sm text-haze">
                 <div className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-lavend" />
+                  <span className="h-2 w-2 rounded-full bg-lavender" />
                   Research sprints, brand tune-ups, motion guidelines
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-lavend" />
+                  <span className="h-2 w-2 rounded-full bg-lavender" />
                   Prototype rigs, developer handoff, performance audits
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-lavend" />
+                  <span className="h-2 w-2 rounded-full bg-lavender" />
                   Embedded collaborations from seed to scale
                 </div>
               </div>
@@ -122,7 +122,7 @@ export default function Home() {
             {caseStudies.map((project, index) => (
               <motion.article
                 key={project.name}
-                className="group grid gap-4 rounded-[32px] border border-hairline/70 bg-ink/50 p-6 transition-colors duration-150 hover:border-lavend"
+                className="group grid gap-4 rounded-[32px] border border-hairline/70 bg-ink/50 p-6 transition-colors duration-150 hover:border-lavender"
                 variants={cards}
                 initial="hidden"
                 whileInView="visible"
@@ -136,8 +136,8 @@ export default function Home() {
                   </span>
                 </div>
                 <p className="text-sm leading-relaxed text-haze group-hover:text-foam">{project.description}</p>
-                <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-lavend">
-                  <span className="h-px w-8 bg-lavend/70" />
+                <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-lavender">
+                  <span className="h-px w-8 bg-lavender/70" />
                   Inquire for release notes
                 </div>
               </motion.article>

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -75,7 +75,7 @@ export default function Resume() {
           <button
             type="button"
             onClick={openContact}
-            className="rounded-full bg-lavend px-5 py-2 text-sm font-semibold uppercase tracking-[0.28em] text-ink transition-colors duration-150 hover:bg-lavend-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+            className="rounded-full bg-lavender px-5 py-2 text-sm font-semibold uppercase tracking-[0.28em] text-ink transition-colors duration-150 hover:bg-lavender-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
           >
             Hire Me
           </button>
@@ -104,7 +104,7 @@ export default function Resume() {
             <ul className="mt-4 flex flex-col gap-3 text-sm leading-relaxed text-haze">
               {item.bullets.map((bullet) => (
                 <li key={bullet} className="flex gap-2">
-                  <span aria-hidden="true" className="mt-1 block h-1 w-1 rounded-full bg-lavend" />
+                  <span aria-hidden="true" className="mt-1 block h-1 w-1 rounded-full bg-lavender" />
                   <span>{bullet}</span>
                 </li>
               ))}
@@ -126,7 +126,7 @@ export default function Resume() {
           <ul className="mt-4 grid gap-3 text-sm text-haze">
             {skills.map((skill) => (
               <li key={skill} className="flex items-center gap-2">
-                <span className="h-2 w-2 rounded-full bg-lavend" />
+                <span className="h-2 w-2 rounded-full bg-lavender" />
                 {skill}
               </li>
             ))}
@@ -142,9 +142,9 @@ export default function Resume() {
           custom={experience.length + 2}
         >
           <h3 className="font-display text-xl text-foam">Tools in regular rotation</h3>
-          <ul className="mt-4 flex flex-wrap gap-3 text-xs uppercase tracking-[0.24em] text-lavend">
+          <ul className="mt-4 flex flex-wrap gap-3 text-xs uppercase tracking-[0.24em] text-lavender">
             {tools.map((tool) => (
-              <li key={tool} className="rounded-full border border-lavend/40 px-3 py-1">
+              <li key={tool} className="rounded-full border border-lavender/40 px-3 py-1">
                 {tool}
               </li>
             ))}

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -58,7 +58,7 @@ export default function Work() {
           <button
             type="button"
             onClick={openContact}
-            className="rounded-full bg-lavend px-5 py-2 text-sm font-semibold uppercase tracking-[0.28em] text-ink transition-colors duration-150 hover:bg-lavend-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+            className="rounded-full bg-lavender px-5 py-2 text-sm font-semibold uppercase tracking-[0.28em] text-ink transition-colors duration-150 hover:bg-lavender-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
           >
             Hire Me
           </button>
@@ -70,7 +70,7 @@ export default function Work() {
         {projects.map((project, index) => (
           <motion.article
             key={project.title}
-            className="rounded-[32px] border border-hairline/60 bg-ink/60 p-8 transition-colors duration-150 hover:border-lavend"
+            className="rounded-[32px] border border-hairline/60 bg-ink/60 p-8 transition-colors duration-150 hover:border-lavender"
             variants={listVariants}
             initial="hidden"
             whileInView="visible"
@@ -84,9 +84,9 @@ export default function Work() {
               </span>
             </div>
             <p className="mt-4 text-base leading-relaxed text-haze">{project.summary}</p>
-            <ul className="mt-6 flex flex-wrap gap-3 text-xs uppercase tracking-[0.28em] text-lavend">
+            <ul className="mt-6 flex flex-wrap gap-3 text-xs uppercase tracking-[0.28em] text-lavender">
               {project.focus.map((item) => (
-                <li key={item} className="rounded-full border border-lavend/40 px-3 py-1 text-lavend">
+                <li key={item} className="rounded-full border border-lavender/40 px-3 py-1 text-lavender">
                   {item}
                 </li>
               ))}

--- a/src/routes/resume/index.tsx
+++ b/src/routes/resume/index.tsx
@@ -188,19 +188,19 @@ export default function ResumeRoute() {
             <button
               type="button"
               onClick={handleExport}
-              className="rounded-full bg-lavend px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-ink transition-colors duration-150 hover:bg-lavend-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend focus-visible:ring-offset-2 focus-visible:ring-offset-ink print:hidden"
+              className="rounded-full bg-lavender px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-ink transition-colors duration-150 hover:bg-lavender-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender focus-visible:ring-offset-2 focus-visible:ring-offset-ink print:hidden"
             >
               Download PDF
             </button>
             <a
               href="mailto:hello@aetherlab.studio"
-              className="rounded-full border border-hairline/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-haze transition-colors duration-150 hover:text-lavend focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend focus-visible:ring-offset-2 focus-visible:ring-offset-ink print:text-black print:border-black"
+              className="rounded-full border border-hairline/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-haze transition-colors duration-150 hover:text-lavender focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender focus-visible:ring-offset-2 focus-visible:ring-offset-ink print:text-black print:border-black"
             >
               Email
             </a>
             <a
               href="https://cal.com/aetherlab/intro"
-              className="rounded-full border border-hairline/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-haze transition-colors duration-150 hover:text-lavend focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend focus-visible:ring-offset-2 focus-visible:ring-offset-ink print:text-black print:border-black"
+              className="rounded-full border border-hairline/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-haze transition-colors duration-150 hover:text-lavender focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender focus-visible:ring-offset-2 focus-visible:ring-offset-ink print:text-black print:border-black"
             >
               Book intro call
             </a>
@@ -228,7 +228,7 @@ export default function ResumeRoute() {
             <ul className="mt-4 flex flex-col gap-3 text-sm text-haze print:text-black">
               {strengths.map((strength) => (
                 <li key={strength} className="flex items-start gap-3">
-                  <span aria-hidden="true" className="mt-[0.45rem] h-1.5 w-1.5 rounded-full bg-lavend print:bg-black" />
+                  <span aria-hidden="true" className="mt-[0.45rem] h-1.5 w-1.5 rounded-full bg-lavender print:bg-black" />
                   <span>{strength}</span>
                 </li>
               ))}
@@ -243,7 +243,7 @@ export default function ResumeRoute() {
                   <p className="text-xs uppercase tracking-[0.28em] text-haze/70 print:text-black">{group.label}</p>
                   <ul className="mt-2 flex flex-wrap gap-2 text-sm text-haze print:text-black">
                     {group.items.map((item) => (
-                      <li key={item} className="rounded-full border border-hairline/50 bg-ink/50 px-3 py-1 text-xs uppercase tracking-[0.22em] text-lavend print:bg-transparent print:text-black print:border-black">
+                      <li key={item} className="rounded-full border border-hairline/50 bg-ink/50 px-3 py-1 text-xs uppercase tracking-[0.22em] text-lavender print:bg-transparent print:text-black print:border-black">
                         {item}
                       </li>
                     ))}
@@ -281,11 +281,11 @@ export default function ResumeRoute() {
           <ol className="resume-timeline mt-6 flex flex-col gap-6">
             {experienceTimeline.map((entry, index) => (
               <li key={`${entry.company}-${entry.start}`} className="relative pl-10">
-                <span className="resume-timeline-marker absolute left-1 top-3 h-full w-px bg-gradient-to-b from-lavend via-lavend/20 to-transparent print:hidden" aria-hidden="true" />
-                <span className="absolute left-0 top-3 flex h-3 w-3 items-center justify-center rounded-full border-2 border-ink bg-lavend print:hidden" aria-hidden="true">
+                <span className="resume-timeline-marker absolute left-1 top-3 h-full w-px bg-gradient-to-b from-lavender via-lavender/20 to-transparent print:hidden" aria-hidden="true" />
+                <span className="absolute left-0 top-3 flex h-3 w-3 items-center justify-center rounded-full border-2 border-ink bg-lavender print:hidden" aria-hidden="true">
                   <span className="h-1.5 w-1.5 rounded-full bg-ink" />
                 </span>
-                <article className="rounded-2xl border border-hairline/50 bg-ink/50 p-5 transition-colors duration-200 hover:border-lavend/60 print:bg-transparent print:border-0">
+                <article className="rounded-2xl border border-hairline/50 bg-ink/50 p-5 transition-colors duration-200 hover:border-lavender/60 print:bg-transparent print:border-0">
                   <details className="group" open={index === 0}>
                     <summary className="list-none cursor-pointer">
                       <div className="flex flex-col gap-4">
@@ -306,8 +306,8 @@ export default function ResumeRoute() {
                           </div>
                         </div>
                         <p className="max-w-2xl text-sm leading-relaxed text-haze print:text-black">{entry.mandate}</p>
-                        <div className="flex items-center gap-2 pt-2 text-xs uppercase tracking-[0.28em] text-haze/60 transition-colors duration-150 group-open:text-lavend print:hidden">
-                          <span className="flex h-5 w-5 items-center justify-center rounded-full border border-hairline/40 text-lavend">
+                        <div className="flex items-center gap-2 pt-2 text-xs uppercase tracking-[0.28em] text-haze/60 transition-colors duration-150 group-open:text-lavender print:hidden">
+                          <span className="flex h-5 w-5 items-center justify-center rounded-full border border-hairline/40 text-lavender">
                             <span className="group-open:hidden">+</span>
                             <span className="hidden group-open:inline">-</span>
                           </span>
@@ -321,7 +321,7 @@ export default function ResumeRoute() {
                       <ul className="mt-3 flex flex-col gap-3 leading-relaxed">
                         {entry.achievements.map((achievement) => (
                           <li key={achievement} className="flex gap-3">
-                            <span aria-hidden="true" className="mt-[0.45rem] h-1.5 w-1.5 rounded-full bg-lavend print:bg-black" />
+                            <span aria-hidden="true" className="mt-[0.45rem] h-1.5 w-1.5 rounded-full bg-lavender print:bg-black" />
                             <span>{achievement}</span>
                           </li>
                         ))}

--- a/src/routes/work/index.tsx
+++ b/src/routes/work/index.tsx
@@ -167,13 +167,13 @@ export default function WorkCollection() {
                 key={filter.value}
                 type="button"
                 onClick={() => setActiveFilter(filter)}
-                className="relative overflow-hidden rounded-full border border-hairline/50 bg-ink/40 px-5 py-2 text-sm font-medium text-haze transition-all duration-200 hover:text-foam focus:outline-none focus-visible:ring-2 focus-visible:ring-lavend/60"
+                className="relative overflow-hidden rounded-full border border-hairline/50 bg-ink/40 px-5 py-2 text-sm font-medium text-haze transition-all duration-200 hover:text-foam focus:outline-none focus-visible:ring-2 focus-visible:ring-lavender/60"
                 data-cursor="hover"
               >
                 {isActive && (
                   <motion.span
                     layoutId="filter-pill"
-                    className="absolute inset-0 rounded-full bg-lavend/20"
+                    className="absolute inset-0 rounded-full bg-lavender/20"
                     transition={{ type: "spring", stiffness: 260, damping: 30 }}
                   />
                 )}
@@ -294,7 +294,7 @@ function WorkCard({ project }: { project: WorkProject }) {
             {project.tags.map((tag) => (
               <span
                 key={tag}
-                className="rounded-full border border-hairline/40 bg-ink/50 px-3 py-1 text-xs uppercase tracking-[0.28em] text-lavend"
+                className="rounded-full border border-hairline/40 bg-ink/50 px-3 py-1 text-xs uppercase tracking-[0.28em] text-lavender"
               >
                 {tag}
               </span>

--- a/src/sections/PortfolioHero.tsx
+++ b/src/sections/PortfolioHero.tsx
@@ -172,10 +172,10 @@ export function PortfolioHero() {
           </motion.p>
           <motion.div className="flex flex-wrap items-center gap-3 text-sm text-haze" variants={identityItemVariants}>
             <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.28em] text-foam">
-              <span className="h-2 w-2 rounded-full bg-lavend" />
+              <span className="h-2 w-2 rounded-full bg-lavender" />
               Portland, OR
             </span>
-            <span className="inline-flex items-center gap-2 rounded-full border border-lavend/40 bg-lavend/10 px-4 py-2 text-xs uppercase tracking-[0.28em] text-lavend">
+            <span className="inline-flex items-center gap-2 rounded-full border border-lavender/40 bg-lavender/10 px-4 py-2 text-xs uppercase tracking-[0.28em] text-lavender">
               Open for Q3 collaborations
             </span>
           </motion.div>
@@ -183,14 +183,14 @@ export function PortfolioHero() {
             <a
               href="#work"
               aria-label="View selected work"
-              className="inline-flex items-center justify-center rounded-full bg-lavend px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-ink transition-colors duration-200 hover:bg-lavend-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+              className="inline-flex items-center justify-center rounded-full bg-lavender px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-ink transition-colors duration-200 hover:bg-lavender-deep hover:text-foam focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
             >
               View Work
             </a>
             <a
               href="/resume.pdf"
               aria-label="Download Rowan Sato resume"
-              className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-foam transition-colors duration-200 hover:border-lavend hover:text-lavend focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavend/60 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+              className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-foam transition-colors duration-200 hover:border-lavender hover:text-lavender focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lavender/60 focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
             >
               Download Resume
             </a>


### PR DESCRIPTION
## Summary
- replace Tailwind class references that used the misspelled `lavend` prefix with `lavender` so they match the palette
- update shared components and pages to rely on the corrected `lavender` utilities for hover, focus, and background styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cec67a4348832bb04b14b59947ac55