### PR TITLE
Clarify starfield number ranges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm run preview
 
 ### Twinkling Algorithm
 
-- 400–600 stars spawn per viewport with randomized size (0.5–2.5px), base brightness (120–200), phase, and twinkle speed (0.5–1.5x).
+- 400â€“600 stars spawn per viewport with randomized size (0.5â€“2.5px), base brightness (120â€“200), phase, and twinkle speed (0.5â€“1.5x).
 - Brightness follows `base + sin(frameCount * 0.02 * twinkleSpeed + phase) * 55`, mapped to the lavender alpha channel for a soft glow.
 - Mouse-relative parallax nudges each star a few pixels from the canvas center while the frame rate is capped at 45 FPS for stability.
 


### PR DESCRIPTION
## Summary
- fix the starfield README description to state proper numeric ranges with hyphenation for counts, sizes, brightness, and twinkle speed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cecfb11724832b9616160f399d9403