### PR TITLE
Configure Vitest jsdom environment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,7 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: "jsdom",
+  },
 });


### PR DESCRIPTION
## Summary
- add a jsdom test environment to the Vite configuration so Vitest runs in a browser-like context

## Testing
- `npm run test -- --run` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68cedc433880832bb4ff6e9d942c852e