### PR TITLE
Fix ContactDrawer status animation JSX

### DIFF
--- a/src/components/ContactDrawer.tsx
+++ b/src/components/ContactDrawer.tsx
@@ -164,11 +164,12 @@ export function ContactDrawer({ open, onClose }: ContactDrawerProps) {
                         key="sent"
                         initial={{ opacity: 0, y: 6 }}
                         animate={{ opacity: 1, y: 0 }}
-                   <motion.div
-  exit={{ opacity: 0, y: -6, transition: { duration: MotionDurations.duration120 } }}
-  className="rounded-full border border-lavender/50 bg-lavender/10 px-4 py-2 text-center text-xs text-lavender"
->
-
+                        exit={{
+                          opacity: 0,
+                          y: -6,
+                          transition: { duration: MotionDurations.duration120 },
+                        }}
+                        className="rounded-full border border-lavender/50 bg-lavender/10 px-4 py-2 text-center text-xs text-lavender"
                       >
                         Sent (stub)
                       </motion.div>


### PR DESCRIPTION
## Summary
- fix the sent status toast markup in ContactDrawer so the JSX compiles
- keep the motion.div animation configuration intact with proper exit transition

## Testing
- npm run build *(fails: TS2688: Cannot find type definition file for 'vitest')*

------
https://chatgpt.com/codex/tasks/task_b_68cee0994298832bb79e2c5c8828e594